### PR TITLE
Add :connection library as dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule Xandra.Mixfile do
   defp deps() do
     [
       {:db_connection, "~> 2.0"},
+      {:connection, "~> 1.0"},
       {:decimal, "~> 1.7", optional: true},
 
       # Dev and test dependencies


### PR DESCRIPTION
Adds the dependency `connection` to the project as it was dropped from `db_connection` since version [2.5.0](https://github.com/elixir-ecto/db_connection/blob/master/CHANGELOG.md), which leads to compilation issues if `db_connection` >= 2.5.0.

Note: In the future, we might was well drop `connection` altogether and replace it with `gen_statem` in the same vein as [db_connection](https://github.com/elixir-ecto/db_connection/pull/275) did it.